### PR TITLE
fix: stop error on created status

### DIFF
--- a/pkg/otlp/audit/comm.go
+++ b/pkg/otlp/audit/comm.go
@@ -31,7 +31,7 @@ func (o *otlpClient) send(ctx context.Context, payload string) error {
 		err = resp.Body.Close()
 	}()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("%w %d", errStatusNotOK, resp.StatusCode)
 	}
 


### PR DESCRIPTION
fix: stop error on created status

on receipt of http code 201, the code raised an error. So expanded the handling for both status ok and statusCreated otherwise error
