### PR TITLE
feat: Add log level trace

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -23,12 +23,16 @@ const (
 	TimeAttribute    = "time"
 	LevelAttribute   = "level"
 	MessageAttribute = "msg"
+	// LevelTrace is a custom log level for trace logging with value -8
+	LevelTrace = slog.Level(-8)
 )
 
 // setLogLevel converts the level string used in the config to a slog.LevelVar
 // and sets the levelVar to the corresponding level.
 func setLogLevel(levelVar *slog.LevelVar, level string) {
 	switch strings.ToLower(level) {
+	case "trace":
+		levelVar.Set(LevelTrace)
 	case "debug":
 		levelVar.Set(slog.LevelDebug)
 	case "info":
@@ -101,6 +105,11 @@ func InitHandlerWithWriter(w io.Writer, cfgLogger commoncfg.Logger, app commoncf
 			levelKey := strings.TrimSpace(cfgLogger.Formatter.Fields.Level)
 			if levelKey == "" {
 				levelKey = a.Key
+			}
+
+			// Handle custom LevelTrace to display as "TRACE" instead of "DEBUG-4"
+			if level, ok := a.Value.Any().(slog.Level); ok && level == LevelTrace {
+				return slog.Attr{Key: levelKey, Value: slog.StringValue("TRACE")}
 			}
 
 			return slog.Attr{Key: levelKey, Value: a.Value}


### PR DESCRIPTION
**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.
Adds the possibility for clients to log with TRACE level.
```

**Special notes for your reviewer**:
``` If no notes, remove the block.

```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.
Clients will be able to log at TRACE level. However, as `slog` is not exposing a trace log function, clients have to use `slog.Log(ctx, LevelTrace, msg, ...)`.
```
