### PR TITLE
feat: fingerprinting of http requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.2
 require (
 	github.com/Dynatrace/OneAgent-SDK-for-Go v1.1.0
 	github.com/davidhoo/jsonpath v1.0.4
+	github.com/envoyproxy/go-control-plane/envoy v1.32.4
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/mcuadros/go-defaults v1.2.0
@@ -41,7 +42,9 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -55,6 +58,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,11 +6,17 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 h1:aQ3y1lwWyqYPiWZThqv1aFbZMiM9vblcSArJRf2Irls=
+github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davidhoo/jsonpath v1.0.4 h1:f31VxArp5bWUV4wbuYI4KsnVpirMq57B5PnDQId4giI=
 github.com/davidhoo/jsonpath v1.0.4/go.mod h1:QUzoZq6f3h3XtLXPCCgapLAQMNuwGCCMwfKiTAf8e5s=
+github.com/envoyproxy/go-control-plane/envoy v1.32.4 h1:jb83lalDRZSpPWW2Z7Mck/8kXZ5CQAFYVjQcdVIr83A=
+github.com/envoyproxy/go-control-plane/envoy v1.32.4/go.mod h1:Gzjc5k8JcJswLjAx1Zm+wSYE20UrLtt7JZMWiWQXQEw=
+github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfUKS7KJ7spH3d86P8=
+github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
@@ -67,6 +73,8 @@ github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNs
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
+github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=

--- a/pkg/fingerprint/fingerprint.go
+++ b/pkg/fingerprint/fingerprint.go
@@ -1,0 +1,46 @@
+// Package fingerprint provides functions to generate a fingerprint from
+// either a standard HTTP request or an envoy HTTP request.
+package fingerprint
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+)
+
+var headerKeys = []string{"user-agent", "accept"}
+
+func FromHTTPRequest(r *http.Request) (string, error) {
+	if r == nil {
+		return "", errors.New("http request is nil")
+	}
+
+	h := sha256.New()
+
+	for _, key := range headerKeys {
+		h.Write([]byte(r.Header.Get(key)))
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func FromEnvoyHTTPRequest(r *envoy_auth.AttributeContext_HttpRequest) (string, error) {
+	if r == nil {
+		return "", errors.New("envoy http request is nil")
+	}
+
+	h := sha256.New()
+
+	for _, key := range headerKeys {
+		if v, ok := r.GetHeaders()[key]; ok {
+			h.Write([]byte(v))
+		} else {
+			h.Write([]byte(""))
+		}
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/pkg/fingerprint/fingerprint_test.go
+++ b/pkg/fingerprint/fingerprint_test.go
@@ -1,0 +1,81 @@
+package fingerprint
+
+import (
+	"net/http"
+	"testing"
+
+	envoy "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+)
+
+func TestAll(t *testing.T) {
+	// create the test cases
+	tests := []struct {
+		name       string
+		req1       *http.Request
+		wantError1 bool
+		req2       *envoy.AttributeContext_HttpRequest
+		wantError2 bool
+	}{
+		{
+			name:       "zero values",
+			wantError1: true,
+			wantError2: true,
+		}, {
+			name:       "empty requests",
+			req1:       &http.Request{Header: http.Header{}},
+			wantError1: false,
+			req2:       &envoy.AttributeContext_HttpRequest{Headers: map[string]string{}},
+			wantError2: false,
+		}, {
+			name: "normal requests",
+			req1: &http.Request{Header: http.Header{
+				"User-Agent": []string{"Foo"},
+				"Accept":     []string{"Bar"},
+			}},
+			wantError1: false,
+			req2: &envoy.AttributeContext_HttpRequest{Headers: map[string]string{
+				"user-agent": "Foo",
+				"accept":     "Bar",
+			}},
+			wantError2: false,
+		},
+	}
+
+	// run the tests
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Act 1
+			h1, err1 := FromHTTPRequest(tc.req1)
+
+			// Assert 1
+			if tc.wantError1 {
+				if err1 == nil {
+					t.Error("expected error, but got nil")
+				}
+			} else {
+				if err1 != nil {
+					t.Errorf("unexpected error: %s", err1)
+				}
+			}
+
+			// Act 2
+			h2, err2 := FromEnvoyHTTPRequest(tc.req2)
+
+			// Assert 2
+			if tc.wantError2 {
+				if err2 == nil {
+					t.Error("expected error, but got nil")
+				}
+			} else {
+				if err2 != nil {
+					t.Errorf("unexpected error: %s", err2)
+				}
+			}
+
+			// Compare the results
+			if tc.wantError1 == tc.wantError2 && h1 != h2 {
+				t.Errorf("fingerprints do not match: %s != %s", h1, h2)
+			}
+		})
+	}
+}


### PR DESCRIPTION
For the secure handling of sessions with the new Session Manager and ExtAuthZ, we need to ensure to communicate with the same client identity. This mitigates attacks, where the session ID got leaked.

This package provides functions to create a fingerprint either based on an http request (used by the Session Manager) or an envoy http request (used by ExtAuthZ).

For the moment the implementation uses the `User-Agent` and `Accept` headers. However, by accepting the whole request we may change this over time without breaking the interface.