### PR TITLE
feat: Add CertWatcher for automatic TLS certificate reloading

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.2
 
 require (
 	github.com/Dynatrace/OneAgent-SDK-for-Go v1.1.0
+	github.com/avast/retry-go/v4 v4.6.1
 	github.com/davidhoo/jsonpath v1.0.4
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-viper/mapstructure/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Dynatrace/OneAgent-SDK-for-Go v1.1.0 h1:fYtSrInkNuXIuvE46i/SI0+Yr1HvD6aIlgm/tFVnls0=
 github.com/Dynatrace/OneAgent-SDK-for-Go v1.1.0/go.mod h1:kCcKw+7c9+/LExeIms6kv2eTbedu+mF/ByuG3SUDVzM=
+github.com/avast/retry-go/v4 v4.6.1 h1:VkOLRubHdisGrHnTu89g08aQEWEgRU7LVEop3GbIcMk=
+github.com/avast/retry-go/v4 v4.6.1/go.mod h1:V6oF8njAwxJ5gRo1Q7Cxab24xs5NCWZBeaHHBklR8mA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/pkg/commoncfg/certwatcher.go
+++ b/pkg/commoncfg/certwatcher.go
@@ -1,0 +1,261 @@
+package commoncfg
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/fsnotify/fsnotify"
+
+	fs "github.com/openkcm/common-sdk/pkg/commonfs/watcher"
+)
+
+const (
+	DefaultAttempts = 3
+	DefaultDelay    = 100 * time.Millisecond
+	DefaultMaxDelay = 5 * time.Second
+)
+
+// ReloadCallback is a function type for certificate reload callbacks
+type ReloadCallback func(*tls.Config, error)
+
+// CertWatcher monitors certificate files for rotation using fs.NotifyWrapper
+type CertWatcher struct {
+	mu           sync.RWMutex
+	mtlsConfig   MTLS
+	tlsConfig    *tls.Config
+	logger       *slog.Logger
+	retryOptions []retry.Option
+	watcher      *fs.NotifyWrapper
+	callbacks    []ReloadCallback
+}
+
+// DefaultRetryOptions returns sensible default retry configuration
+func DefaultRetryOptions() []retry.Option {
+	return []retry.Option{
+		retry.Attempts(DefaultAttempts),
+		retry.Delay(DefaultDelay),
+		retry.MaxDelay(DefaultMaxDelay),
+		retry.DelayType(retry.BackOffDelay),
+		retry.LastErrorOnly(true),
+	}
+}
+
+// NewCertWatcher creates a new certificate watcher for the given MTLS configuration
+func NewCertWatcher(mtlsConfig MTLS, logger *slog.Logger, retryOptions []retry.Option) (*CertWatcher, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	if len(retryOptions) == 0 {
+		retryOptions = DefaultRetryOptions()
+	}
+
+	cw := &CertWatcher{
+		mtlsConfig:   mtlsConfig,
+		logger:       logger,
+		retryOptions: retryOptions,
+		callbacks:    make([]ReloadCallback, 0),
+	}
+
+	// Load initial TLS configuration
+	err := cw.loadTLSConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load initial TLS config: %w", err)
+	}
+
+	// Create and configure the filesystem watcher
+	err = cw.createWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create watcher: %w", err)
+	}
+
+	// Start watching
+	err = cw.watcher.Start()
+	if err != nil {
+		return nil, fmt.Errorf("failed to start watching: %w", err)
+	}
+
+	return cw, nil
+}
+
+// RegisterCallback adds a callback function that will be called when certificates are reloaded
+func (cw *CertWatcher) RegisterCallback(callback ReloadCallback) {
+	cw.mu.Lock()
+	defer cw.mu.Unlock()
+
+	cw.callbacks = append(cw.callbacks, callback)
+	cw.logger.Info("Certificate reload callback registered")
+}
+
+// executeCallbacks executes all registered callbacks with the current TLS config and any error
+func (cw *CertWatcher) executeCallbacks(tlsConfig *tls.Config, err error) {
+	cw.mu.RLock()
+	callbacks := make([]ReloadCallback, len(cw.callbacks))
+	copy(callbacks, cw.callbacks)
+	cw.mu.RUnlock()
+
+	for i, callback := range callbacks {
+		func(idx int, cb ReloadCallback) {
+			defer func() {
+				if r := recover(); r != nil {
+					cw.logger.Error("Certificate reload callback panic",
+						"callback_index", idx,
+						"panic", r)
+				}
+			}()
+
+			cb(tlsConfig, err)
+		}(i, callback)
+	}
+}
+
+// createWatcher creates and configures the fs.NotifyWrapper
+func (cw *CertWatcher) createWatcher() error {
+	certPaths := cw.getCertificatePaths()
+	if len(certPaths) == 0 {
+		return errors.New("no certificate paths found")
+	}
+
+	// Create watcher with certificate paths and handlers
+	watcher, err := fs.NewFSWatcher(
+		fs.OnPaths(certPaths...),
+		fs.WithEventHandler(cw.handleCertEvent),
+		fs.WithErrorEventHandler(cw.handleError),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create fs watcher: %w", err)
+	}
+
+	cw.watcher = watcher
+
+	cw.logger.Info("Certificate watcher configured", "paths", certPaths)
+
+	return nil
+}
+
+// handleCertEvent is the event handler for certificate file changes
+func (cw *CertWatcher) handleCertEvent(event fsnotify.Event) {
+	// Handle both Write and Create events for directory watching
+	// Create events occur when files are atomically replaced (common in k8s)
+	if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) {
+		return
+	}
+
+	cw.logger.Debug("Certificate file changed, reloading...",
+		"file", event.Name,
+		"operation", event.Op.String())
+
+	err := cw.loadTLSConfig()
+	if err != nil {
+		cw.logger.Error("Failed to reload certificate",
+			"file", event.Name,
+			"error", err.Error())
+	}
+}
+
+// handleError is the error handler for filesystem watcher errors
+func (cw *CertWatcher) handleError(err error) {
+	cw.logger.Error("Certificate watcher error", "error", err.Error())
+}
+
+// loadTLSConfig loads or reloads the TLS configuration
+func (cw *CertWatcher) loadTLSConfig() error {
+	var tlsConfig *tls.Config
+
+	err := retry.Do(
+		func() error {
+			var err error
+
+			tlsConfig, err = LoadMTLSConfig(&cw.mtlsConfig)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+		cw.retryOptions...,
+	)
+	if err != nil {
+		// Execute callbacks with error
+		cw.executeCallbacks(nil, fmt.Errorf("failed to load TLS config: %w", err))
+		return fmt.Errorf("failed to load TLS config: %w", err)
+	}
+
+	cw.mu.Lock()
+	cw.tlsConfig = tlsConfig
+	cw.mu.Unlock()
+
+	cw.logger.Info("Certificate loaded successfully")
+
+	// Execute callbacks with successful config
+	cw.executeCallbacks(tlsConfig, nil)
+
+	return nil
+}
+
+// getCertificatePaths extracts file paths from MTLS configuration
+func (cw *CertWatcher) getCertificatePaths() []string {
+	var paths []string
+
+	pathSet := make(map[string]bool) // To avoid duplicate directories
+
+	if cw.mtlsConfig.Cert.Source == FileSourceValue {
+		dir := filepath.Dir(cw.mtlsConfig.Cert.File.Path)
+		if !pathSet[dir] {
+			paths = append(paths, dir)
+			pathSet[dir] = true
+		}
+	}
+
+	if cw.mtlsConfig.CertKey.Source == FileSourceValue {
+		dir := filepath.Dir(cw.mtlsConfig.CertKey.File.Path)
+		if !pathSet[dir] {
+			paths = append(paths, dir)
+			pathSet[dir] = true
+		}
+	}
+
+	if cw.mtlsConfig.ServerCA.Source == FileSourceValue {
+		dir := filepath.Dir(cw.mtlsConfig.ServerCA.File.Path)
+		if !pathSet[dir] {
+			paths = append(paths, dir)
+			pathSet[dir] = true
+		}
+	}
+
+	return paths
+}
+
+// GetTLSConfig returns the current TLS configuration
+func (cw *CertWatcher) GetTLSConfig() *tls.Config {
+	cw.mu.RLock()
+	defer cw.mu.RUnlock()
+
+	return cw.tlsConfig
+}
+
+// Reload triggers an immediate certificate reload
+func (cw *CertWatcher) Reload() error {
+	cw.logger.Info("Manual certificate reload triggered")
+	return cw.loadTLSConfig()
+}
+
+// Close stops the certificate watcher
+func (cw *CertWatcher) Close() error {
+	if cw.watcher != nil {
+		err := cw.watcher.Close()
+		if err != nil {
+			cw.logger.Error("Error closing watcher", "error", err.Error())
+		}
+	}
+
+	cw.logger.Info("Certificate watcher stopped")
+
+	return nil
+}

--- a/pkg/commoncfg/certwatcher_test.go
+++ b/pkg/commoncfg/certwatcher_test.go
@@ -1,0 +1,170 @@
+package commoncfg_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"log/slog"
+	"math/big"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkcm/common-sdk/pkg/commoncfg"
+)
+
+func generateValidTestCertificates(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+	// Generate an RSA private key
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	// Create certificate template
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test Org"},
+			Country:      []string{"Test Country"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:  x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+	}
+
+	// Create certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privKey.PublicKey, privKey)
+	require.NoError(t, err)
+
+	// Encode certificate to PEM
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	// Encode private key to PEM using PKCS#1 format (traditional RSA format)
+	keyDER := x509.MarshalPKCS1PrivateKey(privKey)
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: keyDER,
+	})
+
+	// Verify the generated certificate and key can be loaded
+	_, err = tls.X509KeyPair(certPEM, keyPEM)
+	require.NoError(t, err, "Generated certificate and key pair should be valid")
+
+	return certPEM, keyPEM
+}
+
+func createTempCertFile(t *testing.T, content []byte, filename string) string {
+	t.Helper()
+	tmpFile, err := os.CreateTemp(t.TempDir(), filename)
+	require.NoError(t, err)
+
+	_, err = tmpFile.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	return tmpFile.Name()
+}
+
+func createTestCertFiles(t *testing.T) (string, string, string) {
+	t.Helper()
+	certPEM, keyPEM := generateValidTestCertificates(t)
+
+	cert := createTempCertFile(t, certPEM, "cert-*.pem")
+	key := createTempCertFile(t, keyPEM, "key-*.pem")
+	ca := createTempCertFile(t, certPEM, "ca-*.pem")
+
+	return cert, key, ca
+}
+
+func TestCertWatcherReloadAndCallback(t *testing.T) {
+	cert, key, ca := createTestCertFiles(t)
+
+	// Clean up files
+	defer func() {
+		err := os.Remove(cert)
+		assert.NoError(t, err)
+		err = os.Remove(key)
+		assert.NoError(t, err)
+		err = os.Remove(ca)
+		assert.NoError(t, err)
+	}()
+
+	mtls := commoncfg.MTLS{
+		Cert: commoncfg.SourceRef{
+			Source: commoncfg.FileSourceValue,
+			File:   commoncfg.CredentialFile{Path: cert, Format: commoncfg.BinaryFileFormat},
+		},
+		CertKey: commoncfg.SourceRef{
+			Source: commoncfg.FileSourceValue,
+			File:   commoncfg.CredentialFile{Path: key, Format: commoncfg.BinaryFileFormat},
+		},
+		ServerCA: commoncfg.SourceRef{
+			Source: commoncfg.FileSourceValue,
+			File:   commoncfg.CredentialFile{Path: ca, Format: commoncfg.BinaryFileFormat},
+		},
+	}
+
+	logger := slog.Default()
+	cw, err := commoncfg.NewCertWatcher(mtls, logger, nil)
+	require.NoError(t, err)
+	require.NotNil(t, cw)
+
+	defer func() {
+		err = cw.Close()
+		assert.NoError(t, err)
+	}()
+
+	var (
+		mu            sync.Mutex
+		callbackCount int
+		lastConfig    *tls.Config
+		lastError     error
+	)
+
+	cw.RegisterCallback(func(cfg *tls.Config, err error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		callbackCount++
+		lastConfig = cfg
+		lastError = err
+	})
+
+	mu.Lock()
+
+	initialCount := callbackCount
+
+	mu.Unlock()
+
+	// Generate new certificates and update files
+	newCertPEM, newKeyPEM := generateValidTestCertificates(t)
+	require.NoError(t, os.WriteFile(cert, newCertPEM, 0644))
+	require.NoError(t, os.WriteFile(key, newKeyPEM, 0600))
+
+	// Wait for file watcher to detect changes
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+
+	finalCount := callbackCount
+	finalConfig := lastConfig
+	finalError := lastError
+
+	mu.Unlock()
+
+	assert.GreaterOrEqual(t, finalCount, initialCount, "Callback should be called")
+
+	if finalCount > initialCount {
+		assert.NotNil(t, finalConfig, "TLS config should not be nil after reload")
+		assert.NoError(t, finalError, "Callback error should be nil on successful reload")
+	}
+}


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
Implements a certificate watcher that automatically monitors TLS certificate files and reloads them when changes are detected. This enables zero-downtime certificate rotation for applications that need to pick up new certificates without restart.

Key features:
- File-based certificate monitoring using fsnotify
- Automatic TLS config reloading when certificates change
- Callback system for applications to react to certificate updates

**Release note**:
feat: Add CertWatcher for automatic TLS certificate reloading with file monitoring capabilities
