### PR TITLE
fix: change SecurityHeadersMiddleware to constructor pattern

### DIFF
--- a/pkg/middleware/security_headers.go
+++ b/pkg/middleware/security_headers.go
@@ -15,19 +15,21 @@ var SecurityHeaderDefaults = map[string]string{
 	"Cross-Origin-Resource-Policy": "same-site",
 }
 
-// SecurityHeadersMiddleware adds baseline HTTP security headers to every response.
-// Content-Security-Policy is managed at the infrastructure level and is omitted here.
-func SecurityHeadersMiddleware(next http.Handler, customHeaders map[string]string) http.Handler {
+// SecurityHeadersMiddleware returns an HTTP middleware that adds baseline security headers to every response.
+// customHeaders overrides or extends the defaults. Content-Security-Policy is managed at the
+// infrastructure level and is omitted from the defaults.
+func SecurityHeadersMiddleware(customHeaders map[string]string) func(http.Handler) http.Handler {
 	headers := make(map[string]string)
 	maps.Copy(headers, SecurityHeaderDefaults)
-
 	maps.Copy(headers, customHeaders)
 
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		for key, value := range headers {
-			w.Header().Set(key, value)
-		}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			for key, value := range headers {
+				w.Header().Set(key, value)
+			}
 
-		next.ServeHTTP(w, r)
-	})
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/pkg/middleware/security_headers_test.go
+++ b/pkg/middleware/security_headers_test.go
@@ -15,7 +15,7 @@ func TestSecurityHeadersMiddleware(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := middleware.SecurityHeadersMiddleware(next, nil)
+	handler := middleware.SecurityHeadersMiddleware(nil)(next)
 
 	t.Run("sets all required security headers", func(t *testing.T) {
 		rec := httptest.NewRecorder()
@@ -42,7 +42,7 @@ func TestSecurityHeadersMiddleware(t *testing.T) {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 
-		middleware.SecurityHeadersMiddleware(nextWithFlag, nil).ServeHTTP(rec, req)
+		middleware.SecurityHeadersMiddleware(nil)(nextWithFlag).ServeHTTP(rec, req)
 
 		assert.True(t, calledNextHandler, "next handler was not called")
 	})
@@ -55,7 +55,7 @@ func TestSecurityHeadersMiddleware(t *testing.T) {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 
-		middleware.SecurityHeadersMiddleware(nextWithOverride, nil).ServeHTTP(rec, req)
+		middleware.SecurityHeadersMiddleware(nil)(nextWithOverride).ServeHTTP(rec, req)
 
 		assert.Equal(t, "public, max-age=3600", rec.Header().Get("Cache-Control"))
 	})
@@ -67,7 +67,7 @@ func TestSecurityHeadersMiddleware(t *testing.T) {
 			"Referrer-Policy":           "no-referrer",
 		}
 
-		handler := middleware.SecurityHeadersMiddleware(next, customHeaders)
+		handler := middleware.SecurityHeadersMiddleware(customHeaders)(next)
 
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -91,7 +91,7 @@ func TestSecurityHeadersMiddleware(t *testing.T) {
 			"Content-Security-Policy": "default-src 'self'",
 		}
 
-		handler := middleware.SecurityHeadersMiddleware(next, customHeaders)
+		handler := middleware.SecurityHeadersMiddleware(customHeaders)(next)
 
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -111,7 +111,7 @@ func TestSecurityHeadersMiddleware(t *testing.T) {
 	t.Run("empty custom headers map does not affect defaults", func(t *testing.T) {
 		customHeaders := map[string]string{}
 
-		handler := middleware.SecurityHeadersMiddleware(next, customHeaders)
+		handler := middleware.SecurityHeadersMiddleware(customHeaders)(next)
 
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -133,7 +133,7 @@ func TestSecurityHeadersMiddleware(t *testing.T) {
 			"X-Frame-Options": "",
 		}
 
-		handler := middleware.SecurityHeadersMiddleware(next, customHeaders)
+		handler := middleware.SecurityHeadersMiddleware(customHeaders)(next)
 
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -155,7 +155,7 @@ func TestSecurityHeadersMiddleware(t *testing.T) {
 			"X-Frame-Options": "SAMEORIGIN",
 		}
 
-		handler := middleware.SecurityHeadersMiddleware(next, customHeaders)
+		handler := middleware.SecurityHeadersMiddleware(customHeaders)(next)
 
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)


### PR DESCRIPTION
Change signature from SecurityHeadersMiddleware(next, customHeaders) to SecurityHeadersMiddleware(customHeaders)(next), returning func(http.Handler) http.Handler. This makes it compatible with standard Go HTTP middleware chains without requiring an adapter.

<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.

```

**Special notes for your reviewer**:
``` If no notes, remove the block.

```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.

```
