### PR TITLE
Add wrapper repo fields to BuildInfo

### DIFF
--- a/pkg/commoncfg/config.go
+++ b/pkg/commoncfg/config.go
@@ -454,11 +454,14 @@ type BuildInfo struct {
 }
 
 type Component struct {
-	Branch    string `json:"branch,omitempty"`
-	Org       string `json:"org,omitempty"`
-	Product   string `json:"product,omitempty"`
-	Repo      string `json:"repo,omitempty"`
-	SHA       string `json:"sha,omitempty"`
-	Version   string `json:"version,omitempty"`
-	BuildTime string `json:"buildTime,omitempty"`
+	Branch      string `json:"branch,omitempty"`
+	Org         string `json:"org,omitempty"`
+	Product     string `json:"product,omitempty"`
+	Repo        string `json:"repo,omitempty"`
+	SHA         string `json:"sha,omitempty"`
+	Version     string `json:"version,omitempty"`
+	BuildTime   string `json:"buildTime,omitempty"`
+	WrapperSha  string `json:"wrapperSha,omitempty"`
+	WrapperRepo string `json:"wrapperRepo,omitempty"`
+	WrapperOrg  string `json:"wrapperOrg,omitempty"`
 }


### PR DESCRIPTION
Adds wrapperSha, wrapperRepo, and wrapperOrg fields to the Component struct to support tracking wrapper repository information.

These fields are optional (omitempty) so non-wrapper repos continue to work without changes.

## Context
Wrapper repos that aggregate multiple external dependencies can now track both the wrapper repo and the component repo information in BuildInfo.

## Example output
With this change, wrapper repos will show:
```json
{
  "branch": "refs/tags/v1.8.0",
  "org": "example-org",
  "product": "example-product",
  "repo": "https://github.com/example-org/product",
  "sha": "abc123...",
  "version": "v1.8.0",
  "buildTime": "2026-08-04T14:38:23Z",
  "wrapperSha": "def456...",
  "wrapperRepo": "https://github.com/example-org/wrapper",
  "wrapperOrg": "example-org"
}
```

Non-wrapper repos will not include the wrapper fields (omitted due to omitempty).